### PR TITLE
Update build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -34,7 +34,7 @@ pub fn build(b: *std.Build) void {
         );
     }
 
-    lib.install();
+    _ = b.addInstallArtifact(lib);
 }
 
 const headers = [_][]const u8{

--- a/build.zig
+++ b/build.zig
@@ -34,7 +34,7 @@ pub fn build(b: *std.Build) void {
         );
     }
 
-    _ = b.addInstallArtifact(lib);
+    b.installArtifact(lib);
 }
 
 const headers = [_][]const u8{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
 
     .dependencies = .{
         .freetype = .{
-            .url = "https://github.com/hexops/freetype/archive/910155a791751690ac0c81ab2a11c249375d62fb.tar.gz",
-            .hash = "12203f87212a07f0bb135943494c0edf37b3b3b4320ac7406e4f5eeab93504767a7b",
+            .url = "https://github.com/hexops/freetype/archive/d3b9bfb88e6832e75b49907efc9fe343b4b620bd.tar.gz",
+            .hash = "1220d6752594b317fc7147aec4935af74b4644c526ff20582ebaf2e2456725f92999",
         },
     },
 }


### PR DESCRIPTION
update lib.install() as this is now deprecated in favour of `_ = b.addInstallArtifact(lib);`

NOTE:
This PR should only be merge after the PR to brotli have been merged and this PR have had its dependency hash updated to the lastest of brotli