### PR TITLE
Fix package name typo in build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "freetype",
+    .name = "harfbuzz",
     .version = "0.0.0",
     .dependencies = .{
         .freetype = .{


### PR DESCRIPTION
Just a small typo fix.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.